### PR TITLE
Update install.sh

### DIFF
--- a/aider/website/install.sh
+++ b/aider/website/install.sh
@@ -27,7 +27,7 @@ fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
 else
-    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/astral-sh/uv/releases/download/0.5.9"
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/astral-sh/uv/releases/download/${APP_VERSION}"
 fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
@@ -57,10 +57,10 @@ usage() {
     cat <<EOF
 uv-installer.sh
 
-The installer for uv 0.5.9
+The installer for uv $APP_VERSION
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/astral-sh/uv/releases/download/0.5.9
+https://github.com/astral-sh/uv/releases/download/$APP_VERSION
 then unpacks the binaries and installs them to the first of the following locations
 
     \$XDG_BIN_HOME


### PR DESCRIPTION
This pull request includes changes to the `aider/website/install.sh` script to make the installer more flexible by using a variable for the application version. This allows the script to dynamically adjust to different versions of the application without requiring manual updates to the version number.

Key changes include:

* Updated `ARTIFACT_DOWNLOAD_URL` to use the `APP_VERSION` variable instead of a hardcoded version number.
* Modified the `usage()` function to display the application version dynamically using the `APP_VERSION` variable.